### PR TITLE
Round Information JSON Serialization for Post-Processing

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Content.Server.Announcements;
 using Content.Server.Discord;
 using Content.Server.GameTicking;
@@ -402,6 +404,20 @@ namespace Content.Server.GameTicking
 
             _replayRoundPlayerInfo = listOfPlayerInfoFinal;
             _replayRoundText = roundEndText;
+
+            var roundEndData = new Dictionary<string, string>
+            {
+                {"gamemodeTitle", gamemodeTitle},
+                {"roundEndText", roundEndText},
+                {"roundDuration", roundDuration.ToString()},
+                {"roundId", RoundId.ToString()},
+                {"playerCount", listOfPlayerInfoFinal.Length.ToString()},
+            };
+            var roundEndDataJson = JsonSerializer.Serialize(roundEndData);
+            string path = "roundEndData.json";
+            FileInfo file = new FileInfo(path);
+            file.Directory?.Create();
+            File.WriteAllText(file.FullName, roundEndDataJson);
         }
 
         private async void SendRoundEndDiscordMessage()


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR adds functionality to serialize round information into a JSON file for post-processing. The round information includes the game mode title, round end text, round duration, round ID, and player count.

## Why / Balance
The addition of JSON serialization for round information allows for easier post-processing and analysis of round data. This can be useful for server administrators, developers, and the community to better understand gameplay dynamics and make informed decisions about future updates and balancing.

## Technical details
The implementation involves creating a dictionary to store the relevant round information, serializing it into JSON format, and writing it to a file named `roundEndData.json`. The file is saved in the server's directory for easy access.

## Media
- [ ] This PR does not require an ingame showcase.

## Breaking changes
No breaking changes are introduced in this PR.

**Changelog**
:cl:
- add: Added JSON serialization for round information for post-processing.